### PR TITLE
`Element` parameter now can be plain DOM element

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const steps = [
     intro: 'test 2',
   },
   {
-    element: '.selector3',
+    element: document.querySelectorAll('.selector3')[0],
     intro: 'test 3',
   },
 ];
@@ -105,7 +105,7 @@ const steps = [
 
 | Name | Description | Type | Required |
 | --- | --- | :---: | :---: |
-| `element` | CSS selector to use for the step. | String | |
+| `element` | CSS selector to use for the step or DOM element | String or DOM element | |
 | `intro` | The tooltip text. | String | ✅ |
 | `position` | Position of the tooltip. | String | |
 | `tooltipClass` | CSS class of the tooltip. | String | |

--- a/src/components/Steps/index.js
+++ b/src/components/Steps/index.js
@@ -18,7 +18,7 @@ export default class Steps extends Component {
     initialStep: PropTypes.number.isRequired,
     steps: PropTypes.arrayOf(
       PropTypes.shape({
-        element: PropTypes.string,
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Element)]),
         intro: PropTypes.string.isRequired,
         position: introJsPropTypes.tooltipPosition,
         tooltipClass: PropTypes.string,
@@ -204,7 +204,13 @@ export default class Steps extends Component {
    * @param  {number} stepIndex - The index of the step to update.
    */
   updateStepElement = stepIndex => {
-    const element = document.querySelector(this.introJs._options.steps[stepIndex].element);
+    let element;
+
+    if (typeof this.introJs._options.steps[stepIndex].element === 'string') {
+      element = document.querySelector(this.introJs._options.steps[stepIndex].element);
+    } else {
+      element = this.introJs._options.steps[stepIndex].element;
+    }
 
     if (element) {
       this.introJs._introItems[stepIndex].element = element;


### PR DESCRIPTION
This is very useful if we have multiple DOM element with the same class name. E.g:

const steps = {
        element: document.querySelectorAll(`.example`)[0],
        intro: 'Intro here',
      },
      {
        element: document.querySelectorAll(`.example`)[1],
        intro: 'Intro here,
      }
