### PR TITLE
Update `Step.element` allowable types

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const steps = [
 
 | Name | Description | Type | Required |
 | --- | --- | :---: | :---: |
-| `element` | CSS selector to use for the step. | String | |
+| `element` | CSS selector to use for the step. | String \| HTMLElement \| Element | |
 | `intro` | The tooltip content. | String \| React element | ✅ |
 | `position` | Position of the tooltip. | String | |
 | `tooltipClass` | CSS class of the tooltip. | String | |


### PR DESCRIPTION
Include `HTMLElement` and `Element` as part of the allowable types to a step element.

There was a previous PR #81 that made this fix but the docs were not updated.