### PR TITLE
Fixes for next.js

### DIFF
--- a/src/components/Steps/index.js
+++ b/src/components/Steps/index.js
@@ -19,7 +19,7 @@ export default class Steps extends Component {
     initialStep: PropTypes.number.isRequired,
     steps: PropTypes.arrayOf(
       PropTypes.shape({
-        element: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Element)]),
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
         intro: PropTypes.node.isRequired,
         position: introJsPropTypes.tooltipPosition,
         tooltipClass: PropTypes.string,


### PR DESCRIPTION
This throws an error in next.js because instanceOf(Element) will not work for SSR.
The usage of dynamic import isn't exactly a solution but a workaround to a problem that only involves typechecking. 
PropTypes.element should work for it instead.
