### PR TITLE
feat: :label: Added `title` attribute in the interface `Step`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add missing TypeScript `title` attribute type to steps.
+
 ## 0.6.0
 
 * The `onBeforeChange` callback now receives the `nextElement` as second parameter.

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,11 @@ declare module 'intro.js-react' {
      * Position of the tooltip.
      */
     position?: string;
+
+    /**
+     * The tooltip title.
+    */
+    title?:string
     /**
      * CSS class of the tooltip.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,8 @@ declare module 'intro.js-react' {
     /**
      * The tooltip title.
     */
-    title?:string
+    title?: string
+
     /**
      * CSS class of the tooltip.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,12 +15,10 @@ declare module 'intro.js-react' {
      * Position of the tooltip.
      */
     position?: string;
-
     /**
      * The tooltip title.
     */
     title?: string
-
     /**
      * CSS class of the tooltip.
      */


### PR DESCRIPTION

<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

Ref to : https://github.com/HiDeoo/intro.js-react/issues/89

**Describe the pull request**

Added the `title` attribute inside the _Step_ interface, it works without errors.

**Why**

The `title` attribute was missing, and can be used without any errors.

**How**

By adding a new key inside the interface _Step_ inside the `index.d.ts` file.

**Screenshots**

<img width="623" alt="index d ts" src="https://user-images.githubusercontent.com/68734155/189853269-d75ca053-b6c1-401c-bd29-7530ab7af31a.png">

<!-- Feel free to add additional comments. -->
