### PR TITLE
Fix return type of onBeforeChange method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Update TypeScript `onBeforeChange` return type to support promises.
+
 ## 0.7.0
 
 * Add missing TypeScript `title` attribute type to steps.

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ declare module 'intro.js-react' {
      * If you want to prevent the transition to the next / previous step, you can return false in this callback
      * (available since intro.js 2.8.0).
      */
-    onBeforeChange?(nextStepIndex: number, nextElement: Element): void | false;
+    onBeforeChange?(nextStepIndex: number, nextElement: Element): void | false | Promise<void | false>;
     /**
      * Callback called after changing the current step.
      */


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

![image](https://user-images.githubusercontent.com/72147960/203497681-ddc920f4-02ee-44a4-b42b-62b12af0880f.png)

![image](https://user-images.githubusercontent.com/72147960/203497795-af91a8aa-f7e9-4e1b-a0fb-95308e1c4bec.png)

A clear and concise description of what is being fixed, added or modified.

Add return type Promise<void | false> to onBeforeChange method

Why are these changes necessary?

Can't use async functions in callback

If applicable, add screenshots to help explain what is being modified.

<!-- Feel free to add additional comments. -->
